### PR TITLE
Add E-Divisive Mean algorithm

### DIFF
--- a/src/signal_processing_algorithms/energy_statistics/e_divisive.c
+++ b/src/signal_processing_algorithms/energy_statistics/e_divisive.c
@@ -3,12 +3,182 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>
+#include <float.h>
 
 /* public functions */
 bool t_stat_values(double *distances, double * values, int length);
 bool calculate_distance_matrix(double *series, double *distances, int length);
 double calculate_t(double cross_term, double x_term, double y_term, int x_len, int y_len);
 double square_sum(double * distances, int length, int row_start, int row_end, int column_start, int column_end);
+
+bool largest_q(double * distances, double * largest_q_result, int length, int min_cluster_size);
+double sum_fixed_column(double * distances, int length, int row_start, int row_end, int column);
+double sum_fixed_row(double * distances, int length, int row, int column_start, int column_end);
+
+/**
+ * Calculate the largest Q value and its index by using the E-Divisive Mean algorithm.
+ *
+ * @param distances The NxN double array that contains the distances.
+ * @param largest_q_result An array that stores the result
+ * array[0]: if 1, than a largest Q was computed
+ * array[1]: largest Q value
+ * array[2]: Index dividing the cluster (a change point candidate)
+ * @param length The length of the series of values.
+ * #param min_cluster_size The minimum amount of data points for a cluster.
+ */
+bool largest_q(double * distances, double * largest_q_result, int length, int min_cluster_size) {
+    // Please see
+    // src/signal_processing_algorithms/energy_statistics/energy_statistics.py:_calculate_largest_q
+    // for an illustration on how the E-Divisive Mean algorithm works. This knowledge may be required
+    // to understand the following calculation.
+    //
+    // The goal of this function is to compute all Q values as efficient as possible, therefore all kinds
+    // of conditions are avoided.
+    
+    // Use double to avoid casting
+    double x_size;
+    double y_size;
+
+    double x = 0.0;
+    double y = 0.0;
+    double xy = 0.0;
+
+    double q;
+
+    // Initialize result array
+    largest_q_result[0] = -DBL_MAX;
+    largest_q_result[1] = -DBL_MAX;
+    largest_q_result[2] = -DBL_MAX;
+
+    // Index from the end of the 'left' cluster (X)
+    int end_x = min_cluster_size - 1;
+    // Index from the end of the 'right' cluster (Y)
+    int end_y = end_x + min_cluster_size;
+
+    // ###########################
+    // 1. Calculate Q value for X and Y with each having min_cluster_size elements.
+    // We need to perfom this operation at the beginning to prepare the cache.
+    // ###########################
+    for (int row = 0; row < end_x; row++) {
+        x += sum_fixed_row(distances, length, row, row + 1, end_x + 1);
+    }
+    for (int row = end_x + 1; row < end_y; row++){
+        y += sum_fixed_row(distances, length, row, row + 1, end_y + 1);
+    }
+    for (int row = 0; row < end_x + 1; row++) {
+        xy += sum_fixed_row(distances, length, row, end_x + 1, end_y + 1);
+    }
+
+    x_size = end_x + 1;
+    y_size = (end_y + 1) - x_size;
+    q = ((2.0 / (x_size * y_size)) * xy) - ((2.0 / (x_size * (x_size - 1))) * x) - ((2.0 / (y_size * (y_size - 1))) * y);
+    q *= (x_size * y_size) / (x_size + y_size);
+    if (q > largest_q_result[1]) {
+        largest_q_result[0] = 1;
+        largest_q_result[1] = q;
+        largest_q_result[2] = end_x + 1;
+    }
+
+    double y_cache[length];
+    y_cache[end_y] = y;
+    double xy_cache[length];
+    xy_cache[end_y] = xy;
+
+    // ###########################
+    // 2. Keep number of elements of the left cluster (X) constant and increase the number of elements of the right cluster (Y)
+    // - x-value: Does not change as left cluster (X) stays constant.
+    // - y-value: Incrementally compute the y-value by using the old y-value and adding the difference of the newly added data point.
+    // - xy:value: See y-value.
+    // ###########################
+    end_y++;
+    for (;end_y < length; end_y++) {
+        y_cache[end_y] = y_cache[end_y - 1] + sum_fixed_column(distances, length, end_x + 1, end_y, end_y);
+        xy_cache[end_y] = xy_cache[end_y - 1] + sum_fixed_column(distances, length, 0, end_x + 1, end_y);
+
+        y = y_cache[end_y];
+        xy = xy_cache[end_y];
+        x_size = end_x + 1;
+        y_size = (end_y + 1) - x_size;
+        q = ((2.0 / (x_size * y_size)) * xy) - ((2.0 / (x_size * (x_size - 1))) * x) - ((2.0 / (y_size * (y_size - 1))) * y);
+        q *= (x_size * y_size) / (x_size + y_size);
+        if (q > largest_q_result[1]) {
+            largest_q_result[0] = 1;
+            largest_q_result[1] = q;
+            largest_q_result[2] = end_x + 1;
+        }
+    }
+
+    // ###########################
+    // 3. Increase left side and perform step 2 now for each increase of the left side.
+    // x-value: Incrementally compute the x-value by using the old x-value and adding the difference of the newly added data point.
+    // y -value: See x-value.
+    // xy-value: See x-value.
+    // ###########################
+    end_x++;
+    for (;; end_x++) {
+        end_y = end_x + min_cluster_size;
+        if (end_y >= length) {
+            break;
+        }
+
+        double add_x = sum_fixed_column(distances, length, 0, end_x, end_x);
+        x += add_x;
+        for (; end_y < length; end_y++) {
+            double add_y = sum_fixed_row(distances, length, end_x, end_x + 1, end_y + 1);
+            y_cache[end_y] -= add_y;
+            xy_cache[end_y] += (add_y - add_x);
+
+            y = y_cache[end_y];
+            xy = xy_cache[end_y];
+            x_size = end_x + 1;
+            y_size = (end_y + 1) - x_size;
+            q = ((2.0 / (x_size * y_size)) * xy) - ((2.0 / (x_size * (x_size - 1))) * x) - ((2.0 / (y_size * (y_size - 1))) * y);
+            q *= (x_size * y_size) / (x_size + y_size);
+            if (q > largest_q_result[1]) {
+                largest_q_result[0] = 1;
+                largest_q_result[1] = q;
+                largest_q_result[2] = end_x + 1;
+            }
+        }
+    }
+    return true;
+}
+
+/**
+ * Calculate the sum of terms in a NxN distance matrix within
+ * a fixed row [row, row) x [column_start, column_end).
+ *
+ * @param distances The NxN distance matrix.
+ * @param length The length of one dimension of the distance matrix, i.e. the integer N.
+ * @param row Index of the row.
+ * @param column_start Index of the column where the square begins (inclusive).
+ * @param column_end Index of the column where the square ends (exclusive).
+ */
+double sum_fixed_row(double * distances, int length, int row, int column_start, int column_end) {
+    double sum = 0.0;
+    for(int column = column_start; column < column_end; column++) {
+        sum = sum + distances[row * length + column];
+    }
+    return sum;
+}
+
+/**
+ * Calculate the sum of terms in a NxN distance matrix within
+ * a fixed column [row_start, row_end) x [column, column).
+ *
+ * @param distances The NxN distance matrix.
+ * @param length The length of one dimension of the distance matrix, i.e. the integer N.
+ * @param row_start Index of the row where the square begins (inclusive).
+ * @param row_end Index of the row where the square ends (exclusive).
+ * @param column Index of the column.
+ */double sum_fixed_column(double * distances, int length, int row_start, int row_end, int column) {
+    double sum = 0.0;
+    for(int row = row_start; row < row_end; row++) {
+        sum = sum + distances[row * length + column];
+    }
+    return sum;
+}
+
 
 /**
  * Calculate the pairwise distances within the input series.

--- a/src/signal_processing_algorithms/energy_statistics/energy_statistics.py
+++ b/src/signal_processing_algorithms/energy_statistics/energy_statistics.py
@@ -9,6 +9,7 @@ from more_itertools import pairwise
 from signal_processing_algorithms.energy_statistics.cext_calculator import (
     C_EXTENSION_LOADED,
     calculate_distance_matrix,
+    calculate_largest_q,
     calculate_t_values,
 )
 
@@ -150,12 +151,294 @@ def _calculate_t_stats(distance_matrix: np.ndarray, use_c_if_possible: bool = Tr
     return statistics
 
 
+def _calculate_largest_q(
+    distance_matrix: np.ndarray, min_cluster_size: int, use_c_if_possible: bool = True
+) -> Tuple[float, Optional[int]]:
+    """
+    Find the largest Q value using the E-Divisive Mean algorithm.
+
+    :param distance_matrix: The distance matrix.
+    :param min_cluster_size: The minimum number of data points for a cluster.
+    :return: The value and the index of the maximum Q-value.
+    """
+    if min_cluster_size < 2:
+        print("Invalid min cluster size!")
+        exit(1)
+
+    tmp_best: Tuple[float, Optional[int]] = (-1 * np.inf, None)
+    if len(distance_matrix) < 2 * min_cluster_size:
+        return tmp_best
+
+    if use_c_if_possible and C_EXTENSION_LOADED:
+        return calculate_largest_q(distance_matrix, min_cluster_size)
+
+    def q(end_x: int, end_y: int, cache: dict) -> float:
+        """
+        Calculate the Q value for two given clusters.
+
+        :param endx: Index from the end of the left cluster (X).
+        :param end_y: Index from the end of the right cluster (Y).
+        :param cache: By proceeding incrementally when calculating the largest Q value in a
+          time series, intermediate values can be reused. This cache serves as such a storage.
+        :return: Returns the calculated Q value.
+        """
+        # For more efficient computation, we compute the distance matrix of all values.
+        # - We compute the absolute value (as the absolute value is used in the forumlas)
+        # - The diagonal is '0'
+        # - The matrix is symmetric
+        # Data: [1, 1, 1, 2, 4, 7, 9]
+        # distance_matrix (the matrix if formatted as it due to better visualization in the next
+        # steps):
+        # [ 0 ,  0 ,  0 ,  1 ,  3 ,  6 ,  8 ]
+        # [ 0 ,  0 ,  0 ,  1 ,  3 ,  6 ,  8 ]
+        # [ 0 ,  0 ,  0 ,  1 ,  3 ,  6 ,  8 ]
+        # [ 1 ,  1 ,  1 ,  0 ,  2 ,  5 ,  7 ]
+        # [ 3 ,  3 ,  3 ,  2 ,  0 ,  3 ,  5 ]
+        # [ 6 ,  6 ,  6 ,  5 ,  3 ,  0 ,  2 ]
+        # [ 8 ,  8 ,  8 ,  7 ,  5 ,  2 ,  0 ]
+        #
+        # Example:
+        # IMPORTANT NOTE: The index of this exxample starts at 1 and not at 0! To make the
+        # connection to the formula clearer if you look at the example next to the paper.
+        # For efficiency, we do not use the diagonal as these values are always 0.
+        #
+        # end_x = 3; end_y = 6
+        # X = [1, 1, 1]; Y = [2, 4, 7]
+        # -------------
+        # How to calculate x, y, xy. Values marked with paranthesis will be summed up:
+        #
+        # Calculate X (SUM 1<=i<k<=len(X): (|Xi - Xk|))
+        # [ 0 , (0), (0),  1 ,  3 ,  6 ,  8 ] # i = 1
+        # [ 0 ,  0 , (0),  1 ,  3 ,  6 ,  8 ] # i = 2
+        # [ 0 ,  0 ,  0 ,  1 ,  3 ,  6 ,  8 ]
+        # [ 1 ,  1 ,  1 ,  0 ,  2 ,  5 ,  7 ]
+        # [ 3 ,  3 ,  3 ,  2 ,  0 ,  3 ,  5 ]
+        # [ 6 ,  6 ,  6 ,  5 ,  3 ,  0 ,  2 ]
+        # [ 8 ,  8 ,  8 ,  7 ,  5 ,  2 ,  0 ]
+        # x = 0
+
+        def x_original() -> float:
+            # end_x = 2; end_y = 5 (indexed at 0)
+            # range: [0, 1]
+            # distance_matrix[0, 1:3]
+            # distance_matrix[1, 2:3]
+            return sum(np.sum(distance_matrix[row, row + 1 : end_x + 1]) for row in range(0, end_x))
+
+        # Calculate Y (SUM 1<=j<k<=len(Y): (|Yj - Yk|))
+        # [ 0 ,  0 ,  0 ,  1 ,  3 ,  6 ,  8 ]
+        # [ 0 ,  0 ,  0 ,  1 ,  3 ,  6 ,  8 ]
+        # [ 0 ,  0 ,  0 ,  1 ,  3 ,  6 ,  8 ]
+        # [ 1 ,  1 ,  1 ,  0 , (2), (5),  7 ] # j = 1
+        # [ 3 ,  3 ,  3 ,  2 ,  0 , (3),  5 ] # j = 2
+        # [ 6 ,  6 ,  6 ,  5 ,  3 ,  0 ,  2 ]
+        # [ 8 ,  8 ,  8 ,  7 ,  5 ,  2 ,  0 ]
+        # y = 10
+
+        def y_original() -> float:
+            # end_x = 2; end_y = 5 (indexed at 0)
+            # range: [3, 4]
+            # distance_matrix[3, 4:6]
+            # distance_matrix[4, 5:6]
+            return sum(
+                np.sum(distance_matrix[row, row + 1 : end_y + 1]) for row in range(end_x + 1, end_y)
+            )
+
+        # Calculate XY (SUM 1<=i<=len(X); 1<=j<=len(Y): (|Xi - Yj|))
+        # [ 0 ,  0 ,  0 , (1), (3), (6),  8 ] # i = 1
+        # [ 0 ,  0 ,  0 , (1), (3), (6),  8 ] # i = 2
+        # [ 0 ,  0 ,  0 , (1), (3), (6),  8 ] # i = 3
+        # [ 1 ,  1 ,  1 ,  0 ,  2 ,  5 ,  7 ]
+        # [ 3 ,  3 ,  3 ,  2 ,  0 ,  3 ,  5 ]
+        # [ 6 ,  6 ,  6 ,  5 ,  3 ,  0 ,  2 ]
+        # [ 8 ,  8 ,  8 ,  7 ,  5 ,  2 ,  0 ]
+        # xy = 30
+
+        def xy_original() -> float:
+            # end_x = 2; end_y = 5 (indexed at 0)
+            # range: [0, 1, 2]
+            # distance_matrix[0, 3:6]
+            # distance_matrix[1, 3:6]
+            # distance_matrix[2, 3:6]
+            return sum(
+                np.sum(distance_matrix[row, end_x + 1 : end_y + 1]) for row in range(0, end_x + 1)
+            )
+
+        # How is caching used?
+        # Caching will be explained based on the example given above. We store in each step for the
+        # n and m value the respective x, y and xy values. We re-use these values and just
+        # add/substract the new values. For all examples, we consider the scenario of increasing n
+        # and increasing m.
+        #
+        # ### Caching for 'x' - increase 'end_x' ###
+        # Current: end_x = 3; end_y = 6 (marked with '()')
+        # Next: end_x = 4; end_y = 6 (new values marked with '[]')
+        # X = [1, 1, 1, 2]; Y = [4, 7] (X changed, Y changed)
+        # New values: rows '1 until (end_x-1)'; column 'end_x'
+        # [ 0 , (0), (0), [1],  3 ,  6 ,  8 ]
+        # [ 0 ,  0 , (0), [1] , 3 ,  6 ,  8 ]
+        # [ 0 ,  0 ,  0 , [1],  3 ,  6 ,  8 ]
+        # [ 1 ,  1 ,  1 ,  0 ,  2 ,  5 ,  7 ]
+        # [ 3 ,  3 ,  3 ,  2 ,  0 ,  3 ,  5 ]
+        # [ 6 ,  6 ,  6 ,  5 ,  3 ,  0 ,  2 ]
+        # [ 8 ,  8 ,  8 ,  7 ,  5 ,  2 ,  0 ]
+        #
+        # ### Caching for 'x' - increase 'end_y' ###
+        # Current: end_x = 3; end_y = 6 (marked with '()')
+        # Next: end_x = 3; end_y = 7
+        # X = [1, 1, 1]; Y = [2, 4, 7, 9] (Y changed)
+        # New values: -
+        # [ 0 , (0), (0),  1 ,  3 ,  6 ,  8 ]
+        # [ 0 ,  0 , (0),  1 ,  3 ,  6 ,  8 ]
+        # [ 0 ,  0 ,  0 ,  1 ,  3 ,  6 ,  8 ]
+        # [ 1 ,  1 ,  1 ,  0 ,  2 ,  5 ,  7 ]
+        # [ 3 ,  3 ,  3 ,  2 ,  0 ,  3 ,  5 ]
+        # [ 6 ,  6 ,  6 ,  5 ,  3 ,  0 ,  2 ]
+        # [ 8 ,  8 ,  8 ,  7 ,  5 ,  2 ,  0 ]
+
+        def x_cache() -> Optional[float]:
+            # end_x = 3; end_y = 5 (indexed at 0)
+            # distance_matrix[0:3, 3]
+            prev_x = cache["x"].get(end_x - 1)
+            if prev_x is not None:
+                return prev_x + np.sum(distance_matrix[0:end_x, end_x])
+            return None
+
+        # ### Caching for 'y' - increase 'end_x' ###
+        # Current: end_x = 3; end_y = 6 (marked with '()')
+        # Next: end_x = 4; end_y = 6 (removed values marked with '<>')
+        # X = [1, 1, 1, 2]; Y = [4, 7] (X changed, Y changed)
+        # Removed values: row 'end_x'; columns '(end_x+1) until end_y'
+        # [ 0 ,  0 ,  0 ,  1 ,  3 ,  6 ,  8 ]
+        # [ 0 ,  0 ,  0 ,  1 ,  3 ,  6 ,  8 ]
+        # [ 0 ,  0 ,  0 ,  1 ,  3 ,  6 ,  8 ]
+        # [ 1 ,  1 ,  1 ,  0 , <2>, <5>,  7 ]
+        # [ 3 ,  3 ,  3 ,  2 ,  0 , (3),  5 ]
+        # [ 6 ,  6 ,  6 ,  5 ,  3 ,  0 ,  2 ]
+        #
+        # ### Caching for 'y' - increase 'end_y' ###
+        # Current: end_x = 3; end_y = 6 (marked with '()')
+        # Next: end_x = 3; end_y = 7 (new values marked with '[]')
+        # X = [1, 1, 1]; Y = [2, 4, 7, 9] (Y changed)
+        # New values: rows '(end_x+1) until (end_y-1)'; column 'end_y'
+        # [ 0 ,  0 ,  0 ,  1 ,  3 ,  6 ,  8 ]
+        # [ 0 ,  0 ,  0 ,  1 ,  3 ,  6 ,  8 ]
+        # [ 0 ,  0 ,  0 ,  1 ,  3 ,  6 ,  8 ]
+        # [ 1 ,  1 ,  1 ,  0 , (2), (5), [7]]
+        # [ 3 ,  3 ,  3 ,  2 ,  0 , (3), [5]]
+        # [ 6 ,  6 ,  6 ,  5 ,  3 ,  0 , [2]]
+        # [ 8 ,  8 ,  8 ,  7 ,  5 ,  2 ,  0 ]
+
+        def y_cache() -> Optional[float]:
+            prev_y = cache["y"].get((end_x - 1, end_y))
+            if prev_y is not None:
+                # end_x = 3; end_y = 5 (indexed at 0)
+                # distance_matrix[3, 4:6]
+                return prev_y - np.sum(distance_matrix[end_x, end_x + 1 : end_y + 1])
+
+            prev_y = cache["y"].get((end_x, end_y - 1))
+            if prev_y is not None:
+                # end_x = 2; end_y = 6 (indexed at 0)
+                # distance_matrix[3:6, 6]
+                return prev_y + np.sum(distance_matrix[end_x + 1 : end_y, end_y])
+
+            return None
+
+        # ### Caching for 'xy' - increase 'end_x' ###
+        # Current: end_x = 3; end_y = 6 (marked with '()')
+        # Next: end_x = 4; end_y = 6 (new values marked with '[]'; removed values marked with '<>')
+        # X = [1, 1, 1, 2]; Y = [4, 7] (X changed, Y changed)
+        # New values: row 'end_x'; columns '(end_x+1) until end_xy'
+        # Removed values: rows '1 until (end_x-1)'; column 'end_x'
+        # [ 0 ,  0 ,  0 , <1>, (3), (6),  8 ]
+        # [ 0 ,  0 ,  0 , <1>, (3), (6),  8 ]
+        # [ 0 ,  0 ,  0 , <1>, (3), (6),  8 ]
+        # [ 1 ,  1 ,  1 ,  0 , [2], [5],  7 ]
+        # [ 3 ,  3 ,  3 ,  2 ,  0 ,  3 ,  5 ]
+        # [ 6 ,  6 ,  6 ,  5 ,  3 ,  0 ,  2 ]
+        # [ 8 ,  8 ,  8 ,  7 ,  5 ,  2 ,  0 ]
+        #
+        # ### Caching for 'xy' - increase 'm' ###
+        # Current: end_x = 3; end_y = 6 (marked with '()')
+        # Next: end_x = 3; end_y = 7 (new values marked with '[]')
+        # X = [1, 1, 1]; Y = [2, 4, 7, 9] (Y changed)
+        # New values: rows '1 until end_x'; column 'end_y'
+        # [ 0 ,  0 ,  0 , (1), (3), (6), [8]]
+        # [ 0 ,  0 ,  0 , (1), (3), (6), [8]]
+        # [ 0 ,  0 ,  0 , (1), (3), (6), [8]]
+        # [ 1 ,  1 ,  1 ,  0 ,  2 ,  5 ,  7 ]
+        # [ 3 ,  3 ,  3 ,  2 ,  0 ,  3 ,  5 ]
+        # [ 6 ,  6 ,  6 ,  5 ,  3 ,  0 ,  2 ]
+        # [ 8 ,  8 ,  8 ,  7 ,  5 ,  2 ,  0 ]
+
+        def xy_cache() -> Optional[float]:
+            prev_xy = cache["xy"].get((end_x - 1, end_y))
+            if prev_xy is not None:
+                # end_x = 3; end_y = 5 (indexed at 0)
+                # distance_matrix[3, 4:6]
+                # distance_matrix[0:3, 3]
+                return (
+                    prev_xy
+                    + np.sum(distance_matrix[end_x, end_x + 1 : end_y + 1])
+                    - np.sum(distance_matrix[0:end_x, end_x])
+                )
+            prev_xy = cache["xy"].get((end_x, end_y - 1))
+            if prev_xy is not None:
+                # end_x = 2; end_y = 6 (indexed at 0)
+                # distance_matrix[0:3, 6]
+                return prev_xy + np.sum(distance_matrix[0 : end_x + 1, end_y])
+            return None
+
+        x = x_cache()
+        if x is None:
+            x = x_original()
+
+        y = y_cache()
+        if y is None:
+            y = y_original()
+
+        xy = xy_cache()
+        if xy is None:
+            xy = xy_original()
+
+        cache["x"][end_x] = x
+        cache["y"][(end_x, end_y)] = y
+        cache["xy"][(end_x, end_y)] = xy
+
+        # Math: How to get rid of the binomial coefficient
+        # n choose 2
+        # = n! / (2! * (n-2)!)
+        # = n * (n-1) * (n-2)! / (2 * (n-2)!)
+        # = n * (n-1) / 2
+
+        x_size = end_x + 1
+        y_size = (end_y + 1) - x_size
+        xy = (2.0 / (x_size * y_size)) * xy
+        x = (2.0 / (x_size * (x_size - 1))) * x
+        y = (2.0 / (y_size * (y_size - 1))) * y
+        e = xy - x - y
+        return ((x_size * y_size) / (x_size + y_size)) * e
+
+    tmp_cache: Dict[str, Dict[int, float]] = {"x": {}, "y": {}, "xy": {}}
+    for tau in range(min_cluster_size - 1, len(distance_matrix) - min_cluster_size):
+        for kappa in range(tau + min_cluster_size, len(distance_matrix)):
+            # Create two clusters out of the time series
+            # 1 <= tau < kappa <= len(distance_matrix:
+            # Xt = [Z1, Z1, ..., Zt]
+            # Yk = [Zt+1, Zt+1, ... Zk]
+            tmp = q(tau, kappa, tmp_cache)
+            if tmp > tmp_best[0]:
+                tmp_best = (tmp, tau + 1)
+
+    return tmp_best
+
+
 def _get_next_significant_change_point(
     distances: np.ndarray,
     change_points: List[int],
     memo: Dict[Tuple[int, int], Tuple[int, float]],
     pvalue: float,
     permutations: int,
+    min_cluster_size: Optional[int],
 ) -> Optional[int]:
     """
     Calculate the next significant change point.
@@ -168,6 +451,9 @@ def _get_next_significant_change_point(
     :param memo: cache.
     :param pvalue: p value for the permutation test.
     :param permutations: Number of permutations for the permutation test.
+    :param min_cluster_size: The minimum number of data points for a cluster.
+    If min_cluster_size is 'None', the old (original) algorithm is used.
+    If min_cluster_size is >= 2, the E-DIvisive Mean algorithm is used.
     :return: The next most likely change point if one exists.
     """
     windows = [0] + sorted(change_points) + [len(distances)]
@@ -177,11 +463,22 @@ def _get_next_significant_change_point(
             candidates.append(memo[bounds])
         else:
             a, b = bounds
-            stats = _calculate_t_stats(distances[a:b, a:b])
-            idx = int(np.argmax(stats))
-            new = (idx + a, stats[idx])
+            if min_cluster_size is None:
+                stats = _calculate_t_stats(distances[a:b, a:b])
+                idx = int(np.argmax(stats))
+                largest_q = stats[idx]
+            else:
+                largest_q, idx = _calculate_largest_q(  # type:ignore[assignment]
+                    distances[a:b, a:b], min_cluster_size
+                )
+                if idx is None:
+                    # Cluster too small
+                    continue
+            new = (idx + a, largest_q)
             candidates.append(new)
             memo[bounds] = new
+    if len(candidates) == 0:
+        return None
     best_candidate = max(candidates, key=lambda x: x[1])
     better_num = 0
     for _ in range(permutations):
@@ -190,8 +487,17 @@ def _get_next_significant_change_point(
             row_indices = np.arange(b - a) + a
             np.random.shuffle(row_indices)
             shuffled_distances = distances[np.ix_(row_indices, row_indices)]
-            stats = _calculate_t_stats(shuffled_distances)
-            permute_t.append(max(stats))
+            if min_cluster_size is None:
+                stats = _calculate_t_stats(shuffled_distances)
+                largest_q = max(stats)
+            else:
+                largest_q, idx = _calculate_largest_q(  # type:ignore[assignment]
+                    shuffled_distances, min_cluster_size
+                )
+                if idx is None:
+                    # Cluster too small
+                    continue
+            permute_t.append(largest_q)
         best = max(permute_t)
         if best >= best_candidate[1]:
             better_num += 1
@@ -223,6 +529,7 @@ def e_divisive(
     series: Union[List[float], List[List[float]], np.ndarray],
     pvalue: float = 0.05,
     permutations: int = 100,
+    min_cluster_size: Optional[int] = None,
 ) -> List[int]:
     """
     Calculate the change points in the series using e divisive.
@@ -230,6 +537,9 @@ def e_divisive(
     :param series: A series.
     :param pvalue: p value for the permutation test.
     :param permutations: Number of permutations for the permutation test.
+    :param min_cluster_size: The minimum number of data points for a cluster.
+    If min_cluster_size is 'None', the old (original) algorithm is used.
+    If min_cluster_size is >= 2, the E-DIvisive Mean algorithm is used.
     :return: The indices of change points.
     """
     series = _get_valid_input(series)
@@ -237,7 +547,7 @@ def e_divisive(
     distances = _get_distance_matrix(series)
     memo: Dict[Tuple[int, int], Tuple[int, float]] = {}
     while significant_change_point := _get_next_significant_change_point(
-        distances, change_points, memo, pvalue, permutations
+        distances, change_points, memo, pvalue, permutations, min_cluster_size
     ):
         change_points.append(significant_change_point)
     return change_points


### PR DESCRIPTION
This patch adds the E-Divisive Mean algorithm that was defined in this paper:

Matteson, D.S. and James, N.A., 2014. A nonparametric approach for multiple change point analysis of multivariate data. Journal of the American Statistical Association, 109(505), pp.334-345.

Additionally, the attribute `min_cluster_size` is added to the `e_divisive` call. This attribute allows to define the minimum amount of data points for each cluster. This attribute is also used in the reference implementation of the E-Divisive Mean algorithm: https://github.com/cran/ecp/blob/56d4d0ede1b361fd23010b75e5b0c5438de6cf7d/R/e_divisive.R#L42

- If `min_cluster_size` == None: The old algorithm is used
- If `min_cluster_size` >= 2: The new (patched) algorithm is used

To calculate a single change point, the current implementation has a runtime of O(T) (T = length of time series). The E-Divisive Mean algorithm has a runtime of O(T^2).

The following example should illustrate for which groups the Q-value is calculated:

```
time_series = [1, 2, 3, 4, 5, 6]

X = []
Y = [1, 2, 3, 4, 5, 6]

X = [1]
Y = [2, 3, 4, 5, 6]

X = [1, 2]
Y = [3, 4, 5, 6]

X = [1, 2, 3, 4, 5]
Y = [6]

X = [1, 2]
Y = [3, 4]

X = [1, 2]
Y = [3, 4, 5]

X = [1, 2]
Y = [3, 4, 5, 6]

X = [1, 2, 3]
Y = [4, 5]

X = [1, 2, 3]
Y = [4, 5, 6]

X = [1, 2, 3, 4]
Y = [5, 6]
```